### PR TITLE
downgrade wordpress required version to 5.7

### DIFF
--- a/genesis-ads.php
+++ b/genesis-ads.php
@@ -21,7 +21,7 @@
  * License URI:       https://www.gnu.org/licenses/gpl-2.0.txt
  *
  * @requires
- * Requires at least: 7.0
+ * Requires at least: 5.7
  * Requires PHP:      7.4
  */
 

--- a/readme.txt
+++ b/readme.txt
@@ -1,7 +1,7 @@
 === Ads for Genesis ===
 Contributors: advancedads
 Tags: genesis, adsense, ads, ad, amazon, adverts, advertisement, banners, rotation, studiopress, genesis framework
-Requires at least: 7.0
+Requires at least: 5.7
 Tested up to: 7.0
 Requires PHP: 7.4
 Stable tag: 2.0.1

--- a/wp.advads
+++ b/wp.advads
@@ -3,7 +3,7 @@
     "name": "Advanced Ads – Genesis",
     "description": "Place ads on various positions within Genesis themes",
     "version": "2.0.1",
-    "requireWP": "7.0",
+    "requireWP": "5.7",
     "requirePHP": "7.4",
     "textDomain": "advanced-ads-genesis",
     "glotpress": "advanced-ads-genesis"


### PR DESCRIPTION
## Description

Downgrade Wordpress required version to 5.7